### PR TITLE
feat: 공통 input 컴포넌트를 구현한다

### DIFF
--- a/src/shared/ui/input/Input.tsx
+++ b/src/shared/ui/input/Input.tsx
@@ -1,3 +1,4 @@
+import { cn } from '@/shared/lib/utils';
 import type { ComponentProps, ReactNode } from 'react';
 import { forwardRef, useId } from 'react';
 
@@ -7,10 +8,6 @@ import { forwardRef, useId } from 'react';
  * - Preset(InputBox): label/suffix/error/helper + a11y 연결
  * - Next 종속 없음. 디자인 토큰은 className으로 오버라이드
  */
-
-/* cx dialog랑 중복되니까 추후 수정 요함 */
-type ClassValue = string | false | null | undefined;
-const cx = (...args: ClassValue[]) => args.filter(Boolean).join(' ');
 
 /* -------------------------------------------------------------------------- */
 /* Primitive: Input (얇게 유지)                                               */
@@ -23,7 +20,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
       ref={ref}
       type={type}
       data-slot="input"
-      className={cx(
+      className={cn(
         // base
         'flex w-full min-w-0 rounded-xl border bg-white px-5 py-3 typo-body-s-medium outline-none transition-[color,box-shadow,border-color]',
         'placeholder:text-gray-500',
@@ -31,11 +28,11 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
         'disabled:cursor-not-allowed disabled:bg-gray-100 disabled:border-gray-200 disabled:text-gray-500',
         // invalid (aria-invalid=true 일 때)
         'aria-invalid:border-primary-700',
-        className,
+        className
       )}
       {...props}
     />
-  ),
+  )
 );
 Input.displayName = 'Input';
 
@@ -77,27 +74,29 @@ export const InputBox = forwardRef<HTMLInputElement, InputBoxProps>(
       required, // Input의 표준 prop(별표 표시에 사용)
       ...inputProps
     },
-    ref,
+    ref
   ) => {
     const autoId = useId();
     const inputId = id ?? `inp-${autoId}`;
 
     const helperId = helperText ? `${inputId}-help` : undefined;
-    const errorId = typeof error === 'string' ? `${inputId}-err` : undefined;
-    const describedBy = [helperId, errorId].filter(Boolean).join(' ') || undefined;
+    const hasErrorText = typeof error === 'string' && error.trim().length > 0;
+    const errorId = hasErrorText ? `${inputId}-err` : undefined;
+    const describedBy =
+      [helperId, errorId].filter(Boolean).join(' ') || undefined;
 
-    const invalid = Boolean(error);
+    const invalid = error === true || hasErrorText;
 
     return (
-      <div className={cx('w-full', className)}>
+      <div className={cn('w-full', className)}>
         {/* label */}
         {label && (
           <label
             htmlFor={inputId}
-            className={cx(
+            className={cn(
               'mb-2 ml-2 block typo-body-s-medium text-gray-700',
               disabled && 'text-gray-400',
-              labelClassName,
+              labelClassName
             )}
           >
             {label}
@@ -119,16 +118,20 @@ export const InputBox = forwardRef<HTMLInputElement, InputBoxProps>(
             disabled={disabled}
             readOnly={readOnly}
             required={required}
-            className={cx(inputClassName, suffix ? 'pr-10' : '', invalid && 'border-primary-700')}
+            className={cn(
+              inputClassName,
+              suffix ? 'pr-10' : '',
+              invalid && 'border-primary-700'
+            )}
             {...inputProps}
           />
 
           {/* suffix */}
           {suffix && (
             <div
-              className={cx(
+              className={cn(
                 'absolute inset-y-0 right-5 flex items-center',
-                disabled ? 'text-gray-300' : 'text-gray-500',
+                disabled ? 'text-gray-300' : 'text-gray-500'
               )}
             >
               {suffix}
@@ -138,17 +141,23 @@ export const InputBox = forwardRef<HTMLInputElement, InputBoxProps>(
 
         {/* helper / error */}
         {typeof error === 'string' && (
-          <p id={errorId} className="mt-2 ml-2 typo-body-s-medium text-primary-600">
+          <p
+            id={errorId}
+            className="mt-2 ml-2 typo-body-s-medium text-primary-600"
+          >
             {error}
           </p>
         )}
         {!error && helperText && (
-          <p id={helperId} className="mt-2 ml-2 typo-body-s-medium text-gray-500">
+          <p
+            id={helperId}
+            className="mt-2 ml-2 typo-body-s-medium text-gray-500"
+          >
             {helperText}
           </p>
         )}
       </div>
     );
-  },
+  }
 );
 InputBox.displayName = 'InputBox';

--- a/src/shared/ui/input/Input.tsx
+++ b/src/shared/ui/input/Input.tsx
@@ -1,0 +1,165 @@
+'use client';
+
+/**
+ * Input primitive + InputBox preset (React + Tailwind)
+ * - Primitive(Input): shadcn 기반, forwardRef
+ * - Preset(InputBox): label/suffix/error/helper + a11y 연결
+ * - Next 종속 없음. 디자인 토큰은 className으로 오버라이드
+ */
+
+import { forwardRef, useId, type ComponentProps, type ReactNode } from 'react';
+
+/* cx: 경량 class join (필요 시 tailwind-merge로 교체 가능) */
+type ClassValue = string | false | null | undefined;
+const cx = (...args: ClassValue[]) => args.filter(Boolean).join(' ');
+
+/* -------------------------------------------------------------------------- */
+/* Primitive: Input (얇게 유지)                                               */
+/* -------------------------------------------------------------------------- */
+export type InputProps = ComponentProps<'input'>;
+
+export const Input = forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, ...props }, ref) => (
+    <input
+      ref={ref}
+      type={type}
+      data-slot="input"
+      className={cx(
+        // base
+        'flex w-full min-w-0 rounded-xl border bg-white px-5 py-3 typo-body-s-medium outline-none transition-[color,box-shadow,border-color]',
+        'placeholder:text-gray-500',
+        // disabled
+        'disabled:cursor-not-allowed disabled:bg-gray-100 disabled:border-gray-200 disabled:text-gray-500',
+        // invalid (aria-invalid=true 일 때)
+        'aria-invalid:border-primary-700',
+        className
+      )}
+      {...props}
+    />
+  )
+);
+Input.displayName = 'Input';
+
+/* -------------------------------------------------------------------------- */
+/* Preset: InputBox (label/suffix/error/helper 포함 컨테이너)                 */
+/* -------------------------------------------------------------------------- */
+export type InputBoxProps = Omit<InputProps, 'id' | 'className'> & {
+  /** 외부에서 id 지정 가능(접근성/테스트), 없으면 자동 생성 */
+  id?: string;
+  /** 라벨(위쪽) — 시맨틱 <label htmlFor> 연결 */
+  label?: ReactNode;
+  /** 라벨 스타일 오버라이드 */
+  labelClassName?: string;
+  /** 입력 도움말(회색 작은 텍스트) */
+  helperText?: ReactNode;
+  /** 에러 상태: true(스타일만) | string(스타일+메시지) */
+  error?: boolean | string;
+  /** 우측 슬롯(아이콘/텍스트) */
+  suffix?: ReactNode;
+  /** 컨테이너 className */
+  className?: string;
+  /** 인풋 자체 className */
+  inputClassName?: string;
+};
+
+export const InputBox = forwardRef<HTMLInputElement, InputBoxProps>(
+  (
+    {
+      id,
+      label,
+      labelClassName,
+      helperText,
+      error,
+      suffix,
+      className,
+      inputClassName,
+      disabled,
+      readOnly,
+      required, // Input의 표준 prop(별표 표시에 사용)
+      ...inputProps
+    },
+    ref
+  ) => {
+    const autoId = useId();
+    const inputId = id ?? `inp-${autoId}`;
+
+    const helperId = helperText ? `${inputId}-help` : undefined;
+    const errorId = typeof error === 'string' ? `${inputId}-err` : undefined;
+    const describedBy =
+      [helperId, errorId].filter(Boolean).join(' ') || undefined;
+
+    const invalid = Boolean(error);
+
+    return (
+      <div className={cx('w-full', className)}>
+        {/* label */}
+        {label && (
+          <label
+            htmlFor={inputId}
+            className={cx(
+              'mb-2 ml-2 block typo-body-s-medium text-gray-700',
+              disabled && 'text-gray-400',
+              labelClassName
+            )}
+          >
+            {label}
+            {required && (
+              <span className="ml-1 text-primary-700" aria-hidden>
+                *
+              </span>
+            )}
+          </label>
+        )}
+
+        <div className="relative">
+          {/* input */}
+          <Input
+            id={inputId}
+            ref={ref}
+            aria-invalid={invalid || undefined}
+            aria-describedby={describedBy}
+            disabled={disabled}
+            readOnly={readOnly}
+            required={required}
+            className={cx(
+              inputClassName,
+              suffix ? 'pr-10' : '',
+              invalid && 'border-primary-700'
+            )}
+            {...inputProps}
+          />
+
+          {/* suffix */}
+          {suffix && (
+            <div
+              className={cx(
+                'absolute inset-y-0 right-5 flex items-center',
+                disabled ? 'text-gray-300' : 'text-gray-500'
+              )}
+            >
+              {suffix}
+            </div>
+          )}
+        </div>
+
+        {/* helper / error */}
+        {typeof error === 'string' ? (
+          <p
+            id={errorId}
+            className="mt-2 ml-2 typo-body-s-medium text-primary-600"
+          >
+            {error}
+          </p>
+        ) : helperText ? (
+          <p
+            id={helperId}
+            className="mt-2 ml-2 typo-body-s-medium text-gray-500"
+          >
+            {helperText}
+          </p>
+        ) : null}
+      </div>
+    );
+  }
+);
+InputBox.displayName = 'InputBox';

--- a/src/shared/ui/input/Input.tsx
+++ b/src/shared/ui/input/Input.tsx
@@ -1,4 +1,5 @@
-'use client';
+import type { ComponentProps, ReactNode } from 'react';
+import { forwardRef, useId } from 'react';
 
 /**
  * Input primitive + InputBox preset (React + Tailwind)
@@ -7,9 +8,7 @@
  * - Next 종속 없음. 디자인 토큰은 className으로 오버라이드
  */
 
-import { forwardRef, useId, type ComponentProps, type ReactNode } from 'react';
-
-/* cx: 경량 class join (필요 시 tailwind-merge로 교체 가능) */
+/* cx dialog랑 중복되니까 추후 수정 요함 */
 type ClassValue = string | false | null | undefined;
 const cx = (...args: ClassValue[]) => args.filter(Boolean).join(' ');
 
@@ -32,11 +31,11 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
         'disabled:cursor-not-allowed disabled:bg-gray-100 disabled:border-gray-200 disabled:text-gray-500',
         // invalid (aria-invalid=true 일 때)
         'aria-invalid:border-primary-700',
-        className
+        className,
       )}
       {...props}
     />
-  )
+  ),
 );
 Input.displayName = 'Input';
 
@@ -78,15 +77,14 @@ export const InputBox = forwardRef<HTMLInputElement, InputBoxProps>(
       required, // Input의 표준 prop(별표 표시에 사용)
       ...inputProps
     },
-    ref
+    ref,
   ) => {
     const autoId = useId();
     const inputId = id ?? `inp-${autoId}`;
 
     const helperId = helperText ? `${inputId}-help` : undefined;
     const errorId = typeof error === 'string' ? `${inputId}-err` : undefined;
-    const describedBy =
-      [helperId, errorId].filter(Boolean).join(' ') || undefined;
+    const describedBy = [helperId, errorId].filter(Boolean).join(' ') || undefined;
 
     const invalid = Boolean(error);
 
@@ -99,7 +97,7 @@ export const InputBox = forwardRef<HTMLInputElement, InputBoxProps>(
             className={cx(
               'mb-2 ml-2 block typo-body-s-medium text-gray-700',
               disabled && 'text-gray-400',
-              labelClassName
+              labelClassName,
             )}
           >
             {label}
@@ -121,11 +119,7 @@ export const InputBox = forwardRef<HTMLInputElement, InputBoxProps>(
             disabled={disabled}
             readOnly={readOnly}
             required={required}
-            className={cx(
-              inputClassName,
-              suffix ? 'pr-10' : '',
-              invalid && 'border-primary-700'
-            )}
+            className={cx(inputClassName, suffix ? 'pr-10' : '', invalid && 'border-primary-700')}
             {...inputProps}
           />
 
@@ -134,7 +128,7 @@ export const InputBox = forwardRef<HTMLInputElement, InputBoxProps>(
             <div
               className={cx(
                 'absolute inset-y-0 right-5 flex items-center',
-                disabled ? 'text-gray-300' : 'text-gray-500'
+                disabled ? 'text-gray-300' : 'text-gray-500',
               )}
             >
               {suffix}
@@ -143,23 +137,18 @@ export const InputBox = forwardRef<HTMLInputElement, InputBoxProps>(
         </div>
 
         {/* helper / error */}
-        {typeof error === 'string' ? (
-          <p
-            id={errorId}
-            className="mt-2 ml-2 typo-body-s-medium text-primary-600"
-          >
+        {typeof error === 'string' && (
+          <p id={errorId} className="mt-2 ml-2 typo-body-s-medium text-primary-600">
             {error}
           </p>
-        ) : helperText ? (
-          <p
-            id={helperId}
-            className="mt-2 ml-2 typo-body-s-medium text-gray-500"
-          >
+        )}
+        {!error && helperText && (
+          <p id={helperId} className="mt-2 ml-2 typo-body-s-medium text-gray-500">
             {helperText}
           </p>
-        ) : null}
+        )}
       </div>
     );
-  }
+  },
 );
 InputBox.displayName = 'InputBox';

--- a/src/shared/ui/input/index.ts
+++ b/src/shared/ui/input/index.ts
@@ -1,0 +1,1 @@
+export { Input, InputBox, type InputBoxProps, type InputProps } from './Input';

--- a/src/shared/ui/input/index.ts
+++ b/src/shared/ui/input/index.ts
@@ -1,1 +1,2 @@
+/* eslint-disable object-curly-newline */
 export { Input, InputBox, type InputBoxProps, type InputProps } from './Input';


### PR DESCRIPTION
## #️⃣ 연관된 이슈 (선택)

#16 

## 📝 작업 내용

공통 Input 컴포넌트 구현했습니다.
shadCN Input 기반으로 구현하여,
요구사항대로 디자인을 적용하였습니다.


개인적인 판단으로 label을 임의로 추가하였고,
추후 필요시 디자인에 맞춰 수정 및 사용할 수 있을 것 같습니다.
helper text와 error text도 디자인쪽과 논의 후 필요에 따라 구성 가능합니다.

Date 선택 등을 위한 suffix도 적용 가능합니다.


**사용 예시**
```typescript
<InputBox value="typing" disabled />
<InputBox placeholder="placeholder" error="100자를 초과할 수 없어요." />
<InputBox label="휴대폰 번호" required placeholder="010-0000-0000" />
```

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

## 💬 리뷰 요구사항(선택)

죄송합니다.
복귀화면 주말에 빠르게 달려볼게요.

아 그리고 작업하다 보니까
린트랑 prettier랑 자꾸 충돌하더라구요,,
한 번 확인해봐야 할 것 같습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 신기능
  * 새 입력 컴포넌트 추가: 기본 Input과 프리셋 InputBox 제공
  * 라벨, 도움말, 오류 메시지, 필수 표시(별표), 우측 접미 요소 지원
  * 비활성/읽기전용/필수 상태 지원 및 나머지 속성 전달
  * 자동 ID 생성과 ARIA 속성(aria-invalid, aria-describedby)으로 접근성 강화
  * 컨테이너/인풋 개별 스타일 커스터마이즈(className, inputClassName) 지원
<!-- end of auto-generated comment: release notes by coderabbit.ai -->