### PR TITLE
feat: comparison 관련 컴포넌트 및 페이지를 구현한다

### DIFF
--- a/src/app/providers/AppRouter.tsx
+++ b/src/app/providers/AppRouter.tsx
@@ -1,17 +1,17 @@
 import { Route, Routes } from 'react-router-dom';
+
+import { AlarmPage } from '@/pages/alarm';
+import { ComparisonAddPage, ComparisonPage } from '@/pages/comparison';
 import { HomePage } from '@/pages/home';
+import { LoginPage } from '@/pages/login';
+import { MyPage } from '@/pages/my';
+import { SignupPage } from '@/pages/signup';
 import {
   SubscriptionDetailPage,
   SubscriptionEditPage,
   SubscriptionsPage,
 } from '@/pages/subscriptions';
-import { ComparisonPage } from '@/pages/comparison';
-import { MyPage } from '@/pages/my';
-import { AlarmPage } from '@/pages/alarm';
-import { LoginPage } from '@/pages/login';
 import { ROUTES } from '@/shared/config/routes';
-import { SignupPage } from '@/pages/signup';
-
 
 export const AppRouter = () => (
   <Routes>
@@ -19,15 +19,11 @@ export const AppRouter = () => (
     <Route path={ROUTES.SIGNUP} element={<SignupPage />} />
     <Route path={ROUTES.HOME} element={<HomePage />} />
     <Route path={ROUTES.SUBSCRIPTIONS} element={<SubscriptionsPage />} />
-    <Route
-      path={ROUTES.SUBSCRIPTION_DETAIL()}
-      element={<SubscriptionDetailPage />}
-    />
-    <Route
-      path={ROUTES.SUBSCRIPTION_EDIT()}
-      element={<SubscriptionEditPage />}
-    />
+    <Route path={ROUTES.SUBSCRIPTION_DETAIL()} element={<SubscriptionDetailPage />} />
+    <Route path={ROUTES.SUBSCRIPTION_EDIT()} element={<SubscriptionEditPage />} />
     <Route path={ROUTES.COMPARISON} element={<ComparisonPage />} />
+    <Route path={ROUTES.COMPARISON_ADD} element={<ComparisonAddPage />} />
+
     <Route path={ROUTES.MY_PAGE} element={<MyPage />} />
     <Route path={ROUTES.ALARM} element={<AlarmPage />} />
 

--- a/src/entities/comparison/model/types.ts
+++ b/src/entities/comparison/model/types.ts
@@ -1,0 +1,73 @@
+// 각 구독의 혜택 정보
+export interface ProductPlanDto {
+  id: number;
+  name: string;
+  price: number;
+  benefit: string;
+}
+
+export interface ProductPlansDto {
+  status: number;
+  code: string;
+  message: string;
+  data: {
+    plans: ProductPlanDto[];
+  };
+}
+
+// 요금제 상세 정보
+export interface PlanDto {
+  planId: number;
+  planName: string;
+  benefit: string;
+}
+
+// 구독 비교 결과로 반환되는 개별 상품 정보
+export interface ProductComparisonDto {
+  id: number;
+  name: string;
+  imageUrl: string;
+  planId: number; // 사용자가 선택한 요금제 ID
+  benefit: string; // 사용자가 선택한 요금제 혜택
+  plans: PlanDto[]; // 해당 서비스의 전체 요금제 목록
+}
+
+// 구독 비교 조회 API 응답 전체
+export interface ProductsComparisonDto {
+  statusCode: number;
+  code: string;
+  message: string;
+  data: {
+    products: ProductComparisonDto[];
+  };
+}
+
+// 구독 서비스 목록의 개별 상품 정보
+export interface ProductDto {
+  productId: number;
+  name: string;
+  category: string;
+  imageUrl: string;
+  minPrice: number;
+  maxPrice: number | null;
+}
+
+// 구독 서비스 전체 조회 API 응답 전체
+export interface Products {
+  status: number;
+  code: string;
+  message: string;
+  data: {
+    products: ProductDto[];
+  };
+}
+
+// 프론트 도메인 모델
+export interface Product {
+  id: number;
+  name: string;
+  category: string;
+  imageUrl: string;
+  minPrice: number;
+  maxPrice: number | null;
+}

--- a/src/entities/comparison/model/types.ts
+++ b/src/entities/comparison/model/types.ts
@@ -54,7 +54,7 @@ export interface ProductDto {
 
 // 구독 서비스 전체 조회 API 응답 전체
 export interface Products {
-  status: number;
+  statusCode: number;
   code: string;
   message: string;
   data: {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,0 @@
-import { clsx, type ClassValue } from 'clsx';
-import { twMerge } from 'tailwind-merge';
-
-export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs));
-}

--- a/src/pages/comparison/ComparisonAddPage.tsx
+++ b/src/pages/comparison/ComparisonAddPage.tsx
@@ -19,7 +19,7 @@ export const ComparisonAddPage = () => {
   const [selectedSubs, setSelectedSubs] = useState<number[]>([]);
 
   const totalSelectedSubs = selectedSubs.length;
-  const diasbledButton = selectedSubs.length > 4 || selectedSubs.length < 1;
+  const disabledButton = selectedSubs.length > 4 || selectedSubs.length < 1;
   const selectButtonTitle = `${totalSelectedSubs < 1 ? '서비스를 선택하세요 (최대 4개 가능)' : `비교할 서비스 추가 (${totalSelectedSubs}/4)`}`;
 
   const filteredServicesByCategory = ALL_SERVICES.filter(service => service.category === category);
@@ -59,7 +59,7 @@ export const ComparisonAddPage = () => {
         <Button
           variant="primary-fill"
           title={selectButtonTitle}
-          disabled={diasbledButton}
+          disabled={disabledButton}
           onClick={handleAddService}
         />
       </footer>

--- a/src/pages/comparison/ComparisonAddPage.tsx
+++ b/src/pages/comparison/ComparisonAddPage.tsx
@@ -1,0 +1,68 @@
+import { useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+import { ALL_SERVICES } from '@/pages/comparison/ComparisonPage';
+import { Button } from '@/shared/ui/button';
+import BackButton from '@/shared/ui/button/BackButton';
+import { MobileLayout } from '@/shared/ui/layout';
+import ComparisonAddCard from '@/widgets/comparison-card/ui/ComparisonAddCard';
+
+export const ComparisonAddPage = () => {
+  // 모든 서비스 가져오기
+  // const mySubs = getMySubscriptions();
+  // const allSub = getSubscriptions();
+
+  const navigate = useNavigate();
+  const location = useLocation();
+  const queryParams = new URLSearchParams(location.search);
+  const category = queryParams.get('category');
+  const [selectedSubs, setSelectedSubs] = useState<number[]>([]);
+
+  const totalSelectedSubs = selectedSubs.length;
+  const diasbledButton = selectedSubs.length > 4 || selectedSubs.length < 1;
+  const selectButtonTitle = `${totalSelectedSubs < 1 ? '서비스를 선택하세요 (최대 4개 가능)' : `비교할 서비스 추가 (${totalSelectedSubs}/4)`}`;
+
+  const filteredServicesByCategory = ALL_SERVICES.filter(service => service.category === category);
+
+  const handleSelectService = (id: number) => {
+    setSelectedSubs(prev =>
+      prev.includes(id) ? prev.filter(subId => subId !== id) : [...prev, id],
+    );
+  };
+
+  const handleAddService = () => {
+    navigate('/comparison', { state: { newSubs: selectedSubs, category } });
+  };
+
+  return (
+    <MobileLayout
+      // TODO: 뒤로 가기 버튼 수정 필요
+      headerProps={{ leftSlot: <BackButton />, centerSlot: '서비스 선택' }}
+      bodyVariant="gray"
+      showBottom={false}
+    >
+      <main className="py-8 space-y-4">
+        {filteredServicesByCategory.map(service => (
+          <ComparisonAddCard
+            key={service.id}
+            serviceName={service.name}
+            imageUrl={service.imageUrl}
+            minPrice={service.minPrice}
+            maxPrice={service.maxPrice}
+            isSelected={selectedSubs.includes(service.id)}
+            setIsSelected={() => handleSelectService(service.id)}
+          />
+        ))}
+      </main>
+
+      <footer className="px-4 w-full m-auto max-w-md pb-[calc(56px+env(safe-area-inset-bottom))]">
+        <Button
+          variant="primary-fill"
+          title={selectButtonTitle}
+          disabled={diasbledButton}
+          onClick={handleAddService}
+        />
+      </footer>
+    </MobileLayout>
+  );
+};

--- a/src/pages/comparison/ComparisonPage.tsx
+++ b/src/pages/comparison/ComparisonPage.tsx
@@ -1,13 +1,259 @@
-import AlarmButton from '@/shared/ui/button/AlarmButton';
-import { MobileLayout } from '@/shared/ui/layout';
+import { useEffect, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 
-export const ComparisonPage = () => (
-  <MobileLayout
-    headerProps={{
-      centerSlot: '비교하기',
-      rightSlot: <AlarmButton />,
-    }}
-  >
-    ComparisonPage
-  </MobileLayout>
-);
+import type { Product } from '@/entities/comparison/model/types';
+import type { CategoryParam, Subscription } from '@/entities/subscription/model/types';
+import { Icons } from '@/shared/assets/icons';
+import { ROUTES } from '@/shared/config/routes';
+import { cn } from '@/shared/lib';
+import { scrollToTop } from '@/shared/lib/scroll';
+import { Button } from '@/shared/ui/button';
+import AlarmButton from '@/shared/ui/button/AlarmButton';
+import { ChipGroup, ChipItem } from '@/shared/ui/category';
+import { Icon } from '@/shared/ui/icon';
+import { MobileLayout } from '@/shared/ui/layout';
+import ComparisonAddSection from '@/widgets/comparison-section/ui/ComparisonAddSection';
+import { ComparisonMySubSection } from '@/widgets/comparison-section/ui/ComparisonMySubSection';
+import ComparisonResultSection from '@/widgets/comparison-section/ui/ComparisonResultSection';
+import RecommendSubSection from '@/widgets/comparison-section/ui/RecommendSubSection';
+
+const CAT_OPTIONS = [
+  { key: 'OTT', label: 'OTT' },
+  { key: 'SHOPPING', label: '쇼핑' },
+  { key: 'MUSIC', label: '음악' },
+  { key: 'CLOUD', label: '클라우드' },
+  { key: 'AI', label: 'AI' },
+  { key: 'PRODUCTIVITY', label: '생산성' },
+  { key: 'EDUCATION', label: '교육' },
+  { key: 'DELIVERY', label: '배달' },
+];
+
+// 전체 서비스 더미 데이터
+export const ALL_SERVICES: Product[] = [
+  {
+    id: 1,
+    name: '넷플릭스',
+    category: 'OTT',
+    imageUrl:
+      'https://images.ctfassets.net/4cd45et68cgf/Rx83JoRDMkYNlMC9MKzcB/2b14d5a59fc3937afd3f03191e19502d/Netflix-Symbol.png?w=700&h=456',
+    minPrice: 15500,
+    maxPrice: 24900,
+  },
+  {
+    id: 2,
+    name: '쿠팡',
+    category: 'SHOPPING',
+    imageUrl:
+      'https://play-lh.googleusercontent.com/X5-X2S0t7G9dTGrPftk-5hXijqRDhwWKxGDs2gBm_kNPcAlO3re4exC_8nekvDhz-H0',
+    minPrice: 15500,
+    maxPrice: null,
+  },
+  {
+    id: 3,
+    name: '웨이브',
+    category: 'OTT',
+    imageUrl:
+      'https://play-lh.googleusercontent.com/7cuI7bdCeZbmc9anRXqpmxZPH92t5NEEbhTnj5by6skhZK_dlUg9kx--gqtLf-8c2K12',
+    minPrice: 15500,
+    maxPrice: 24900,
+  },
+  {
+    id: 4,
+    name: '디즈니+',
+    category: 'OTT',
+    imageUrl: 'https://upload.wikimedia.org/wikipedia/commons/f/fa/Disney_plus_icon.png',
+    minPrice: 15500,
+    maxPrice: null,
+  },
+];
+
+const mySubs: Omit<Subscription, 'isFavorites'>[] = [
+  {
+    id: 5,
+    name: '넷플릭스',
+    category: 'OTT',
+    imageUrl:
+      'https://images.ctfassets.net/4cd45et68cgf/Rx83JoRDMkYNlMC9MKzcB/2b14d5a59fc3937afd3f03191e19502d/Netflix-Symbol.png?w=700&h=456',
+    price: 15500,
+  },
+  {
+    id: 6,
+    name: '네이버 멤버십',
+    category: 'SHOPPING',
+    imageUrl:
+      'https://i.namu.wiki/i/cGNgd9SXcSZZWhnspHt9K4phfEYUwAxXbYGKU4Urx0w34JHgWwhvZquwEWGvOb430zg-eCohFyC6we2URt4DMA.svg',
+    price: 15500,
+  },
+];
+
+export const ComparisonPage = () => {
+  // 내가 구독 중인 서비스 & 모든 서비스 가져오기
+  // const mySubs = getMySubscriptions();
+  // const allSubs = getSubscriptions();
+
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [category, setCategory] = useState<CategoryParam>('OTT');
+  const [selectedSubs, setSelectedSubs] = useState<number[]>([]);
+  const [addedSubs, setAddedSubs] = useState<typeof ALL_SERVICES>([]);
+  const [showResult, setShowResult] = useState<boolean>(false);
+
+  const currentCategoryLabel = CAT_OPTIONS.find(opt => opt.key === category)?.label || null;
+
+  // 내가 구독 중인 서비스
+  const filteredMySubsByCategory = mySubs.filter(service => service.category === category);
+  // 추가한 서비스
+  const filteredAddedSubsByCategory = addedSubs.filter(service => service.category === category);
+
+  const totalSelectedSubs = selectedSubs.length;
+  const disabledCompareButton = totalSelectedSubs > 4 || totalSelectedSubs < 2;
+  const compareButtonTitle = `${totalSelectedSubs < 1 ? '서비스 비교하기 (2개 이상 선택하기)' : `서비스 비교하기 (${totalSelectedSubs}/4)`}`;
+
+  // 추가한 구독 서비스 업데이트
+  useEffect(() => {
+    const { newSubs, category: categoryFromstate } = location.state || {};
+
+    if (newSubs) {
+      const newAddedServices = ALL_SERVICES.filter(service => newSubs.includes(service.id));
+      setAddedSubs(newAddedServices);
+    }
+
+    if (categoryFromstate) {
+      setCategory(categoryFromstate as CategoryParam);
+    }
+
+    if (newSubs || categoryFromstate) {
+      window.history.replaceState({}, document.title);
+    }
+  }, [location.state]);
+
+  const handleCategoryChange = (value: string | null) => {
+    setCategory(value as CategoryParam);
+    setSelectedSubs([]);
+  };
+
+  const handleSelectSub = (id: number) => {
+    setSelectedSubs(prev =>
+      prev.includes(id) ? prev.filter(subId => subId !== id) : [...prev, id],
+    );
+  };
+
+  // 구독 자세히 보기 버튼
+  // TODO: 서비스 혜택 페이지로 이동 수정 필요
+  const handleShowSubBenefitDetailPage = (id: number) => {
+    navigate(`/subscriptions/${id}`);
+  };
+
+  //  카테고리에 해당하는 서비스 목록 페이지로 이동
+  const handleAddComparisonPage = () => {
+    if (category) {
+      navigate(`${ROUTES.COMPARISON_ADD}?category=${category}`);
+    }
+  };
+
+  const handleDeleteSubs = () => {
+    const selectedIdsInCurrentCategory = filteredAddedSubsByCategory
+      .filter(service => selectedSubs.includes(service.id))
+      .map(service => service.id);
+
+    const updatedAddedSubs = addedSubs.filter(
+      service => !selectedIdsInCurrentCategory.includes(service.id),
+    );
+
+    setAddedSubs(updatedAddedSubs);
+    setSelectedSubs([]);
+  };
+
+  const handleShowResultButton = () => {
+    setShowResult(true);
+  };
+
+  return (
+    <MobileLayout
+      headerProps={{
+        centerSlot: '비교하기',
+        rightSlot: <AlarmButton />,
+      }}
+    >
+      <nav aria-label="카테고리 선택" className="mb-2">
+        {/* 카테고리 */}
+        <ChipGroup value={category} onValueChange={handleCategoryChange} className="gap-3 py-2">
+          {CAT_OPTIONS.map(option => (
+            <ChipItem key={option.key} value={option.key} color="red">
+              {option.label}
+            </ChipItem>
+          ))}
+        </ChipGroup>
+      </nav>
+
+      <main className="mb-8">
+        <header className="flex items-center gap-4 py-[10px] mb-[18px]">
+          <h1 className="typo-title-l-bold">비교하기</h1>
+          <span className="typo-body-m-medium">최대 4개까지 선택 가능해요</span>
+        </header>
+
+        {/* 내가 구독 중인 서비스 섹션 */}
+        <section aria-labelledby="my-subs">
+          {filteredMySubsByCategory.length > 0 && (
+            <ComparisonMySubSection
+              category={currentCategoryLabel}
+              mySubs={filteredMySubsByCategory}
+              selectedSubs={selectedSubs}
+              handleSelect={handleSelectSub}
+              handleDetail={handleShowSubBenefitDetailPage}
+            />
+          )}
+        </section>
+
+        {/* 비교할 서비스 추가하기 섹션 */}
+        <section aria-labelledby="added-subs">
+          <ComparisonAddSection
+            category={currentCategoryLabel}
+            addedSubs={filteredAddedSubsByCategory}
+            selectedSubs={selectedSubs}
+            handleSelect={handleSelectSub}
+            handleDetail={handleShowSubBenefitDetailPage}
+            handleAdd={handleAddComparisonPage}
+            handleDelete={handleDeleteSubs}
+          />
+        </section>
+
+        {/* 비교하기 버튼 */}
+        <div className="pt-2">
+          <Button
+            variant="primary-fill"
+            title={compareButtonTitle}
+            disabled={disabledCompareButton}
+            onClick={handleShowResultButton}
+          ></Button>
+        </div>
+      </main>
+
+      {/* 비교하기 결과 섹션 */}
+      {showResult && (
+        <section
+          aria-labelledby="comparison-result"
+          className={cn('bg-gray-50 mb-10 h-[600px]', '-mx-5')}
+        >
+          <ComparisonResultSection />
+        </section>
+      )}
+
+      {/* 맨 위로 스크롤되는 버튼 */}
+      {showResult && (
+        <button
+          onClick={scrollToTop}
+          className="mb-10 typo-body-m-bold flex items-center justify-center w-full gap-[10px] hover:-translate-y-1 transition-transform duration-300 ease-out"
+        >
+          <Icon component={Icons.DoubleUp} />
+          위로 가기
+        </button>
+      )}
+
+      {/* 추천 서비스 섹션 */}
+      <section aria-labelledby="recommend-subs" className="mb-14">
+        <RecommendSubSection />
+      </section>
+    </MobileLayout>
+  );
+};

--- a/src/pages/comparison/index.ts
+++ b/src/pages/comparison/index.ts
@@ -1,1 +1,2 @@
 export { ComparisonPage } from './ComparisonPage';
+export { ComparisonAddPage } from './ComparisonAddPage';

--- a/src/shared/config/routes.ts
+++ b/src/shared/config/routes.ts
@@ -6,6 +6,7 @@ export const ROUTES = {
   SUBSCRIPTION_DETAIL: (id = ':id') => `/subscriptions/${id}`,
   SUBSCRIPTION_EDIT: (id = ':id') => `/edit/subscriptions/${id}`,
   COMPARISON: '/comparison',
+  COMPARISON_ADD: `/add/comparison`,
   MY_PAGE: '/my',
   ALARM: '/alarm',
 };

--- a/src/shared/lib/format.ts
+++ b/src/shared/lib/format.ts
@@ -3,7 +3,10 @@ export const clamp = (n: number, min = 0, max = 100) => Math.min(max, Math.max(m
 export const percent = (used: number, total: number) =>
   total <= 0 ? 0 : clamp(Math.round((used / total) * 100));
 
-export const formatKRW = (n: number) => `${new Intl.NumberFormat('ko-KR').format(Math.round(n))}원`;
+export const formatKRW = (n: number | null) => {
+  if (n === null) return null;
+  return `${new Intl.NumberFormat('ko-KR').format(Math.round(n))}원`;
+};
 
 export const formatKoreanDate = (d = new Date()) => `${d.getMonth() + 1}월 ${d.getDate()}일`;
 
@@ -20,4 +23,12 @@ export const formatDDay = (dateString: string) => {
   if (diffDays === 0) return 'D-Day';
   if (diffDays > 0) return `D-${diffDays}`;
   return `D+${Math.abs(diffDays)}`;
+};
+
+// 한글의 받침 유무
+export const hasKoreanLastConsonantLetter = (text: string | null): boolean | undefined => {
+  if (text === null) return undefined;
+
+  const english = /[a-zA-Z]/;
+  return (text.charCodeAt(text.length - 1) - '가'.charCodeAt(0)) % 28 !== 0 && !english.test(text);
 };

--- a/src/shared/lib/format.ts
+++ b/src/shared/lib/format.ts
@@ -29,6 +29,15 @@ export const formatDDay = (dateString: string) => {
 export const hasKoreanLastConsonantLetter = (text: string | null): boolean | undefined => {
   if (text === null) return undefined;
 
-  const english = /[a-zA-Z]/;
-  return (text.charCodeAt(text.length - 1) - '가'.charCodeAt(0)) % 28 !== 0 && !english.test(text);
+  const trimmed = text.trim();
+  if (!trimmed) return undefined;
+
+  const chars = Array.from(trimmed);
+  const last = chars[chars.length - 1];
+  const code = last.codePointAt(0)!;
+  const HANGUL_BASE = 0xac00;
+  const HANGUL_LAST = 0xd7a3;
+
+  if (code < HANGUL_BASE || code > HANGUL_LAST) return false;
+  return (code - HANGUL_BASE) % 28 !== 0;
 };

--- a/src/shared/lib/scroll.ts
+++ b/src/shared/lib/scroll.ts
@@ -1,0 +1,6 @@
+export const scrollToTop = () => {
+  window.scrollTo({
+    top: 0,
+    behavior: 'smooth',
+  });
+};

--- a/src/shared/ui/button/Button.tsx
+++ b/src/shared/ui/button/Button.tsx
@@ -1,3 +1,5 @@
+import { cn } from '@/shared/lib';
+
 export interface ButtonProps {
   variant: 'primary-stroke' | 'primary-fill';
   title: string;
@@ -29,7 +31,7 @@ const Button = ({ variant, title, onClick, disabled = false, className }: Button
       type="button"
       onClick={onClick}
       disabled={disabled}
-      className={`${baseClasses} ${stateClasses} ${className}`}
+      className={cn(baseClasses, stateClasses, className)}
     >
       <span>{title}</span>
     </button>

--- a/src/shared/ui/button/Button.tsx
+++ b/src/shared/ui/button/Button.tsx
@@ -1,8 +1,9 @@
 export interface ButtonProps {
   variant: 'primary-stroke' | 'primary-fill';
   title: string;
-  onClick: () => void;
+  onClick?: () => void;
   disabled?: boolean;
+  className?: string;
 }
 
 const baseClasses =
@@ -19,18 +20,16 @@ const buttonStyles = {
   },
 };
 
-const Button = ({ variant, title, onClick, disabled = false }: ButtonProps) => {
+const Button = ({ variant, title, onClick, disabled = false, className }: ButtonProps) => {
   const currentVariant = buttonStyles[variant];
-  const stateClasses = disabled
-    ? currentVariant.disabled
-    : currentVariant.enabled;
+  const stateClasses = disabled ? currentVariant.disabled : currentVariant.enabled;
 
   return (
     <button
       type="button"
       onClick={onClick}
       disabled={disabled}
-      className={`${baseClasses} ${stateClasses}`}
+      className={`${baseClasses} ${stateClasses} ${className}`}
     >
       <span>{title}</span>
     </button>

--- a/src/shared/ui/button/IconButton.tsx
+++ b/src/shared/ui/button/IconButton.tsx
@@ -1,21 +1,24 @@
+import React from 'react';
+
 import type { IconProps } from '@/shared/ui/icon';
 import { Icon } from '@/shared/ui/icon';
 
 export interface IconButtonProps {
   icon: IconProps;
   ariaLabel: string;
-  onClick?: () => void;
+  onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  className?: string;
 }
 
-const IconButton = ({ icon, ariaLabel, onClick }: IconButtonProps) => (
-    <button
-      type="button"
-      onClick={onClick}
-      aria-label={ariaLabel}
-      className="inline-flex items-center justify-center"
-    >
-      <Icon {...icon} />
-    </button>
+const IconButton = ({ icon, ariaLabel, onClick, className }: IconButtonProps) => (
+  <button
+    type="button"
+    onClick={onClick}
+    aria-label={ariaLabel}
+    className={`inline-flex items-center justify-center ${className}`}
+  >
+    <Icon {...icon} />
+  </button>
 );
 
 export default IconButton;

--- a/src/shared/ui/button/IconButton.tsx
+++ b/src/shared/ui/button/IconButton.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { cn } from '@/shared/lib';
 import type { IconProps } from '@/shared/ui/icon';
 import { Icon } from '@/shared/ui/icon';
 
@@ -15,7 +16,7 @@ const IconButton = ({ icon, ariaLabel, onClick, className }: IconButtonProps) =>
     type="button"
     onClick={onClick}
     aria-label={ariaLabel}
-    className={`inline-flex items-center justify-center ${className}`}
+    className={cn('inline-flex items-center justify-center', className)}
   >
     <Icon {...icon} />
   </button>

--- a/src/shared/ui/carousel/Carousel.tsx
+++ b/src/shared/ui/carousel/Carousel.tsx
@@ -1,6 +1,6 @@
 import { Children, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 
-import { cn } from '@/lib/utils';
+import { cn } from '@/shared/lib';
 import { PaginationDots } from '@/shared/ui/pagination';
 
 interface CarouselProps {

--- a/src/shared/ui/contents-card/ContentsCard.tsx
+++ b/src/shared/ui/contents-card/ContentsCard.tsx
@@ -1,6 +1,6 @@
 import { forwardRef, type KeyboardEvent, type ReactNode } from 'react';
 
-import { cn } from '@/lib/utils'; // clsx + tailwind-merge 유틸 가정
+import { cn } from '@/shared/lib';
 
 export interface ContentsCardProps {
   /** 왼쪽 영역(태그, 타이틀 등 복합 레이아웃 자유) */

--- a/src/shared/ui/dropdown/Dropdown.tsx
+++ b/src/shared/ui/dropdown/Dropdown.tsx
@@ -1,7 +1,7 @@
 import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
 import * as React from 'react';
 
-import { cn } from '@/lib/utils';
+import { cn } from '@/shared/lib';
 
 export const Dropdown = DropdownMenuPrimitive.Root;
 

--- a/src/shared/ui/header/Header.tsx
+++ b/src/shared/ui/header/Header.tsx
@@ -1,5 +1,7 @@
 import type { ReactNode } from 'react';
 
+import { cn } from '@/shared/lib';
+
 type colorVariant = 'white' | 'primary';
 
 export interface HeaderProps {
@@ -9,24 +11,22 @@ export interface HeaderProps {
   colorVariant?: colorVariant;
 }
 
-const Header = ({
-  leftSlot,
-  centerSlot,
-  rightSlot,
-  colorVariant = 'white',
-}: HeaderProps) => {
+const Header = ({ leftSlot, centerSlot, rightSlot, colorVariant = 'white' }: HeaderProps) => {
   const backgroundColor = colorVariant === 'white' ? 'bg-white' : 'bg-primary-700';
   const textColor = colorVariant === 'white' ? 'text-gray-800' : 'text-white';
 
   return (
     <header
-      className={`grid grid-cols-3 px-5 py-[14px] typo-body-m-bold ${backgroundColor} ${textColor}`}
+      className={cn(
+        // Flexbox 속성 적용
+        `flex items-center justify-between px-5 py-[14px] typo-body-m-bold`,
+        backgroundColor,
+        textColor,
+      )}
     >
-      <div className="flex items-center justify-start">{leftSlot}</div>
-      <div className="flex-grow flex items-center justify-center">
-        {centerSlot}
-      </div>
-      <div className="flex items-center justify-end">{rightSlot}</div>
+      <div className="flex-1 flex justify-start items-center min-w-0">{leftSlot}</div>
+      <div className="flex-1 flex justify-center items-center min-w-0">{centerSlot}</div>
+      <div className="flex-1 flex justify-end items-center min-w-0">{rightSlot}</div>
     </header>
   );
 };

--- a/src/shared/ui/icon/Icon.tsx
+++ b/src/shared/ui/icon/Icon.tsx
@@ -1,4 +1,4 @@
-import { cn } from '@/lib/utils';
+import { cn } from '@/shared/lib';
 import type { IconProps, IconSize } from '@/shared/ui/icon/types';
 
 const sizeToWH = (size: IconSize) => {
@@ -60,12 +60,7 @@ const Icon = (props: IconProps) => {
   if ('src' in props) {
     return (
       <span className={wrapper} aria-label={ariaLabel}>
-        <img
-          src={props.src}
-          alt={props.alt ?? ''}
-          style={{ width, height }}
-          className="block"
-        />
+        <img src={props.src} alt={props.alt ?? ''} style={{ width, height }} className="block" />
       </span>
     );
   }

--- a/src/shared/ui/pagination/PaginationDots.tsx
+++ b/src/shared/ui/pagination/PaginationDots.tsx
@@ -1,4 +1,4 @@
-import { cn } from '@/lib/utils';
+import { cn } from '@/shared/lib';
 
 interface PaginationDotsProps {
   total: number; // 총 개수

--- a/src/shared/ui/progress/ProgressBar.tsx
+++ b/src/shared/ui/progress/ProgressBar.tsx
@@ -1,4 +1,4 @@
-import { cn } from '@/lib/utils';
+import { cn } from '@/shared/lib';
 
 interface ProgressBarProps {
   value: number; // 0~100

--- a/src/shared/ui/tab/Tabs.tsx
+++ b/src/shared/ui/tab/Tabs.tsx
@@ -1,13 +1,10 @@
 import * as TabsPrimitive from '@radix-ui/react-tabs';
 import * as React from 'react';
 
-import { cn } from '@/lib/utils';
+import { cn } from '@/shared/lib';
 
 // Tabs.Root
-export const Tabs = ({
-  className,
-  ...props
-}: React.ComponentProps<typeof TabsPrimitive.Root>) => (
+export const Tabs = ({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Root>) => (
   <TabsPrimitive.Root
     className={cn('flex flex-col flex-grow', className)}
     data-slot="tabs"

--- a/src/widgets/comparison-card/model/types.ts
+++ b/src/widgets/comparison-card/model/types.ts
@@ -1,0 +1,11 @@
+export interface ComparisonCardProps {
+  serviceName: string;
+  imageUrl: string;
+  minPrice: number | null;
+  maxPrice: number | null;
+  isSelected: boolean;
+  setIsSelected: () => void;
+  handleDetail?: () => void;
+  mySub?: boolean;
+  myPrice?: number;
+}

--- a/src/widgets/comparison-card/ui/ComparisonAddCard.tsx
+++ b/src/widgets/comparison-card/ui/ComparisonAddCard.tsx
@@ -1,0 +1,33 @@
+import { formatKRW } from '@/shared/lib/format';
+import type { ComparisonCardProps } from '@/widgets/comparison-card/model/types';
+
+const ComparisonAddCard = ({
+  serviceName,
+  imageUrl,
+  minPrice,
+  maxPrice,
+  isSelected,
+  setIsSelected,
+}: ComparisonCardProps) => (
+    <div
+      className={`bg-white w-full h-20 rounded-xl px-5 py-4 flex border items-center justify-between ${isSelected ? 'border-primary-700' : 'border-white'}`}
+      onClick={setIsSelected}
+    >
+      <div className="flex items-center gap-[22px]">
+        <img src={imageUrl} alt="logo" className="h-12 w-12 rounded-lg bg-gray-200" />
+        <span className="typo-title-m-bold flex-grow">{serviceName}</span>
+      </div>
+
+      <span className="typo-body-m-medium text-right">
+        {maxPrice === null ? (
+          `월 ${formatKRW(minPrice)}`
+        ) : (
+          <>
+            월 {formatKRW(minPrice)} <br /> ~ {formatKRW(maxPrice)}
+          </>
+        )}
+      </span>
+    </div>
+  );
+
+export default ComparisonAddCard;

--- a/src/widgets/comparison-card/ui/ComparisonAddCard.tsx
+++ b/src/widgets/comparison-card/ui/ComparisonAddCard.tsx
@@ -9,25 +9,25 @@ const ComparisonAddCard = ({
   isSelected,
   setIsSelected,
 }: ComparisonCardProps) => (
-    <div
-      className={`bg-white w-full h-20 rounded-xl px-5 py-4 flex border items-center justify-between ${isSelected ? 'border-primary-700' : 'border-white'}`}
-      onClick={setIsSelected}
-    >
-      <div className="flex items-center gap-[22px]">
-        <img src={imageUrl} alt="logo" className="h-12 w-12 rounded-lg bg-gray-200" />
-        <span className="typo-title-m-bold flex-grow">{serviceName}</span>
-      </div>
-
-      <span className="typo-body-m-medium text-right">
-        {maxPrice === null ? (
-          `월 ${formatKRW(minPrice)}`
-        ) : (
-          <>
-            월 {formatKRW(minPrice)} <br /> ~ {formatKRW(maxPrice)}
-          </>
-        )}
-      </span>
+  <div
+    className={`bg-white w-full h-20 rounded-xl px-5 py-4 flex border items-center justify-between ${isSelected ? 'border-primary-700' : 'border-white'}`}
+    onClick={setIsSelected}
+  >
+    <div className="flex items-center gap-[22px]">
+      <img src={imageUrl} alt={serviceName} className="h-12 w-12 rounded-lg bg-gray-200" />
+      <span className="typo-title-m-bold flex-grow">{serviceName}</span>
     </div>
-  );
+
+    <span className="typo-body-m-medium text-right">
+      {maxPrice === null ? (
+        `월 ${formatKRW(minPrice)}`
+      ) : (
+        <>
+          월 {formatKRW(minPrice)} <br /> ~ {formatKRW(maxPrice)}
+        </>
+      )}
+    </span>
+  </div>
+);
 
 export default ComparisonAddCard;

--- a/src/widgets/comparison-card/ui/ComparisonCard.tsx
+++ b/src/widgets/comparison-card/ui/ComparisonCard.tsx
@@ -6,7 +6,6 @@ import { IconButton } from '@/shared/ui/button';
 import { Icon } from '@/shared/ui/icon';
 import type { ComparisonCardProps } from '@/widgets/comparison-card/model/types';
 
-
 const ComparisonCard = ({
   serviceName,
   imageUrl,
@@ -24,7 +23,7 @@ const ComparisonCard = ({
 
   const handleDetailButtonClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
-    handleDetail!();
+    handleDetail?.();
   };
 
   const handleCheckboxClick = (e: React.MouseEvent<HTMLDivElement>) => {
@@ -37,7 +36,7 @@ const ComparisonCard = ({
       ? `월 ${formatKRW(minPrice)}`
       : `월 ${formatKRW(minPrice)} ~ ${formatKRW(maxPrice)}`;
 
-  const mySubPriceInfo = `요금제이름 ${formatKRW(myPrice!)}`;
+  const mySubPriceInfo = myPrice && `요금제이름 ${formatKRW(myPrice)}`;
 
   return (
     <div

--- a/src/widgets/comparison-card/ui/ComparisonCard.tsx
+++ b/src/widgets/comparison-card/ui/ComparisonCard.tsx
@@ -31,6 +31,13 @@ const ComparisonCard = ({
     setIsSelected();
   };
 
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Enter' || e.key === '') {
+      e.preventDefault();
+      setIsSelected();
+    }
+  };
+
   const notMySubPriceInfo =
     maxPrice === null
       ? `월 ${formatKRW(minPrice)}`
@@ -42,6 +49,10 @@ const ComparisonCard = ({
     <div
       className={`px-5 py-4 border rounded-lg w-full h-[125px] flex flex-col items-center justify-center relative transition-colors duration-200 ease-in-out cursor-pointer ${isSelected ? 'border-primary-700' : 'border-gray-100'}`}
       onClick={handleCardClick}
+      tabIndex={0}
+      role="button"
+      aria-pressed={isSelected}
+      onKeyDown={handleKeyDown}
     >
       {!mySub && (
         <div
@@ -60,7 +71,7 @@ const ComparisonCard = ({
         </div>
       )}
 
-      <img src={imageUrl} alt="logo" className="h-10 w-10 bg-gray-200 rounded-lg mb-1" />
+      <img src={imageUrl} alt={serviceName} className="h-10 w-10 bg-gray-200 rounded-lg mb-1" />
 
       <div className="flex items-center">
         <span className="typo-body-s-bold">{serviceName}</span>

--- a/src/widgets/comparison-card/ui/ComparisonCard.tsx
+++ b/src/widgets/comparison-card/ui/ComparisonCard.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+
+import { Icons } from '@/shared/assets/icons';
+import { formatKRW } from '@/shared/lib/format';
+import { IconButton } from '@/shared/ui/button';
+import { Icon } from '@/shared/ui/icon';
+import type { ComparisonCardProps } from '@/widgets/comparison-card/model/types';
+
+
+const ComparisonCard = ({
+  serviceName,
+  imageUrl,
+  minPrice,
+  maxPrice,
+  isSelected,
+  setIsSelected,
+  handleDetail,
+  mySub,
+  myPrice,
+}: ComparisonCardProps) => {
+  const handleCardClick = () => {
+    setIsSelected();
+  };
+
+  const handleDetailButtonClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    handleDetail!();
+  };
+
+  const handleCheckboxClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    e.stopPropagation();
+    setIsSelected();
+  };
+
+  const notMySubPriceInfo =
+    maxPrice === null
+      ? `월 ${formatKRW(minPrice)}`
+      : `월 ${formatKRW(minPrice)} ~ ${formatKRW(maxPrice)}`;
+
+  const mySubPriceInfo = `요금제이름 ${formatKRW(myPrice!)}`;
+
+  return (
+    <div
+      className={`px-5 py-4 border rounded-lg w-full h-[125px] flex flex-col items-center justify-center relative transition-colors duration-200 ease-in-out cursor-pointer ${isSelected ? 'border-primary-700' : 'border-gray-100'}`}
+      onClick={handleCardClick}
+    >
+      {!mySub && (
+        <div
+          className="absolute top-[10px] left-[12px] h-6 w-6 cursor-pointer z-10" // 클릭 가능한 영역 추가
+          onClick={handleCheckboxClick}
+        >
+          <input
+            type="checkbox"
+            className="absolute appearance-none top-0 left-0 rounded-md h-6 w-6 border border-gray-300 p-2 cursor-pointer bg-gray-300 checked:bg-primary-700 checked:border-primary-700 transition-colors"
+            checked={isSelected} // isSelected prop과 연결
+            readOnly // input 자체의 변경은 막고 클릭으로만 제어
+          />
+          <div className="absolute top-0 left-0 pointer-events-none">
+            <Icon component={Icons.Check} className="text-white" />
+          </div>
+        </div>
+      )}
+
+      <img src={imageUrl} alt="logo" className="h-10 w-10 bg-gray-200 rounded-lg mb-1" />
+
+      <div className="flex items-center">
+        <span className="typo-body-s-bold">{serviceName}</span>
+        <IconButton
+          icon={{ component: Icons.Right }}
+          ariaLabel="자세히보기"
+          onClick={handleDetailButtonClick}
+          className="hover:bg-gray-200 rounded-md transition-colors duration-300 ease-in-out"
+        />
+      </div>
+
+      <span className="typo-label-s-medium text-gray-500">
+        {mySub ? mySubPriceInfo : notMySubPriceInfo}
+      </span>
+    </div>
+  );
+};
+
+export default ComparisonCard;

--- a/src/widgets/comparison-section/model/types.ts
+++ b/src/widgets/comparison-section/model/types.ts
@@ -1,0 +1,20 @@
+import type { Product } from '@/entities/comparison/model/types';
+import type { Subscription } from '@/entities/subscription/model/types';
+
+export interface ComparisonMySubSectionProps {
+  category: string | null;
+  mySubs: Omit<Subscription, 'isFavorites'>[];
+  selectedSubs: number[];
+  handleSelect: (id: number) => void;
+  handleDetail: (id: number) => void;
+}
+
+export interface ComparisonAddSectionProps {
+  category: string | null;
+  addedSubs: Product[];
+  selectedSubs: number[];
+  handleSelect: (id: number) => void;
+  handleDetail: (id: number) => void;
+  handleAdd: () => void;
+  handleDelete: () => void;
+}

--- a/src/widgets/comparison-section/ui/ComparisonAddSection.tsx
+++ b/src/widgets/comparison-section/ui/ComparisonAddSection.tsx
@@ -1,0 +1,74 @@
+import { Icons } from '@/shared/assets/icons';
+import { cn } from '@/shared/lib';
+import { hasKoreanLastConsonantLetter } from '@/shared/lib/format';
+import { Icon } from '@/shared/ui/icon';
+import ComparisonCard from '@/widgets/comparison-card/ui/ComparisonCard';
+import type { ComparisonAddSectionProps } from '@/widgets/comparison-section/model/types';
+
+const ComparisonAddSection = ({
+  category,
+  addedSubs,
+  selectedSubs,
+  handleSelect,
+  handleDetail,
+  handleAdd,
+  handleDelete,
+}: ComparisonAddSectionProps) => {
+  const disabledAddButton = addedSubs.length > 3;
+  const showDeleteButton = addedSubs.some(service => selectedSubs.includes(service.id));
+
+  return (
+    <section className="py-[10px] space-y-4 mb-[18px]">
+      <header className="flex justify-between items-center">
+        <h2 className="flex typo-body-m-bold gap-1">
+          비교하고 싶은
+          <span className="text-primary-700">
+            {category}
+            {hasKoreanLastConsonantLetter(category) ? '을' : '를'} 추가해보세요!
+          </span>
+        </h2>
+
+        {/* 추가한 서비스가 있을 때만 삭제하기 버튼 나타내기 */}
+        {showDeleteButton && (
+          <button className="typo-body-s-bold" onClick={handleDelete}>
+            삭제하기
+          </button>
+        )}
+      </header>
+
+      <div className="grid grid-cols-2 gap-x-[14px] gap-y-4">
+        {/* 서비스 추가 시, 보여지는 카드 */}
+        {addedSubs.map(service => (
+            <ComparisonCard
+              key={service.id}
+              serviceName={service.name}
+              imageUrl={service.imageUrl}
+              minPrice={service.minPrice}
+              maxPrice={service.maxPrice}
+              isSelected={selectedSubs.includes(service.id)}
+              setIsSelected={() => handleSelect(service.id)}
+              handleDetail={() => handleDetail(service.id)}
+            />
+          ))}
+
+        {/* OTT 추가 버튼 */}
+        <button
+          className={cn(
+            `px-5 py-4 border-[1.5px] rounded-lg w-full flex flex-col justify-center border-dashed h-[125px] gap-[2px] text-gray-500`,
+            `bg-gray-50 border-gray-200 hover:text-primary-700 hover:border-primary-700`,
+            `disabled:bg-gray-100 disabled:border-gray-300 disabled:pointer-events-none`,
+            `transition-colors duration-200 ease-in-out`,
+          )}
+          onClick={handleAdd}
+          disabled={disabledAddButton}
+          aria-label={`${category} 추가하기`}
+        >
+          <Icon component={Icons.Plus} size="xl" />
+          <span className={cn('typo-body-m-bold')}>{category} 추가</span>
+        </button>
+      </div>
+    </section>
+  );
+};
+
+export default ComparisonAddSection;

--- a/src/widgets/comparison-section/ui/ComparisonMySubSection.tsx
+++ b/src/widgets/comparison-section/ui/ComparisonMySubSection.tsx
@@ -1,0 +1,35 @@
+import ComparisonCard from '@/widgets/comparison-card/ui/ComparisonCard';
+import type { ComparisonMySubSectionProps } from '@/widgets/comparison-section/model/types';
+
+export const ComparisonMySubSection = ({
+  category,
+  mySubs,
+  selectedSubs,
+  handleSelect,
+  handleDetail,
+}: ComparisonMySubSectionProps) => (
+    <section className="py-[10px] space-y-4 mb-[10px]">
+      <header className="flex typo-body-m-bold">
+        <h2 className="typo-body-m-bold">
+          <span className="text-primary-700">내가 구독 중인</span> {category}
+        </h2>
+      </header>
+
+      <div className="grid grid-cols-2 gap-[14px]">
+        {mySubs.map(service => (
+            <ComparisonCard
+              key={service.id}
+              serviceName={service.name}
+              imageUrl={service.imageUrl}
+              minPrice={null}
+              maxPrice={null}
+              isSelected={selectedSubs.includes(service.id)}
+              setIsSelected={() => handleSelect(service.id)}
+              handleDetail={() => handleDetail(service.id)}
+              mySub={true}
+              myPrice={service.price}
+            />
+          ))}
+      </div>
+    </section>
+  );

--- a/src/widgets/comparison-section/ui/ComparisonResultSection.tsx
+++ b/src/widgets/comparison-section/ui/ComparisonResultSection.tsx
@@ -1,0 +1,10 @@
+const ComparisonResultSection = () => (
+    <section className="p-5">
+      {/* TODO 로딩 스켈레톤 */}
+      <header>
+        <h2 className="typo-title-l-bold">비교 결과</h2>
+      </header>
+    </section>
+  );
+
+export default ComparisonResultSection;

--- a/src/widgets/comparison-section/ui/RecommendSubSection.tsx
+++ b/src/widgets/comparison-section/ui/RecommendSubSection.tsx
@@ -1,0 +1,19 @@
+const RecommendSubSection = () => (
+    <section>
+      <header className="flex items-center gap-5 mb-[18px] ">
+        <h1 className="typo-title-l-bold">이런 서비스는 어때요?</h1>
+      </header>
+
+      <div className="bg-gray-50 rounded-[10px] px-[15px] py-[30px] space-y-5">
+        <h2 className="typo-body-m-bold">추천하는 서비스</h2>
+
+        {/* 랜덤으로 카테고리에 해당하는 2개 서비스 보여주기 */}
+        <div className="space-y-4">
+          <div className="px-5 py-4 bg-white rounded-[10px] w-full h-[84px]"></div>
+          <div className="px-5 py-4 bg-white rounded-[10px] w-full h-[84px]"></div>
+        </div>
+      </div>
+    </section>
+  );
+
+export default RecommendSubSection;


### PR DESCRIPTION
## #️⃣ 연관된 이슈 (선택)

> ex) #이슈번호, #이슈번호

## 📝 작업 내용

- 구현하신 카테고리 칩을 사용해 카테고리 별 비교페이지를 구현했습니다 (url 변경 x)
  -  내가 구독중인 서비스 섹션
   - 비교하고 싶은 서비스 섹션
   - 위로가기 버튼 
- 비교 추가 페이지는 category params를 받아 카테고리 별 서비스 리스트를 보여줍니다
- 추후 api 연결 및 훅 정리가 필요합니다

TODO: 비교 결과, 추천 서비스 섹션 구현하기

https://github.com/user-attachments/assets/90ee0461-e322-4395-8825-f84877583a91


> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 구독 비교 기능 확장: 카테고리 필터, 내 구독/추가 섹션, 비교 결과 및 추천 섹션 제공
  - 비교 추가 화면 및 비교 시작 경로(새 라우트) 추가, 최대 4개 항목 선택 지원
- **Improvements**
  - 가격 표시 개선: 단일/범위 표기 및 null 안전 처리
  - 버튼/아이콘 컴포넌트에 스타일(className) 및 유연한 클릭 처리 추가
  - 헤더 레이아웃을 Flex로 전환해 정렬 개선
- **Refactor**
  - 공통 클래스명/유틸 경로 정리 및 내부 구조 통합
<!-- end of auto-generated comment: release notes by coderabbit.ai -->