### PR TITLE
feat: 내 구독 상세 상단 identity 부분 컴포넌트를 구현한다

### DIFF
--- a/src/app/providers/AppRouter.tsx
+++ b/src/app/providers/AppRouter.tsx
@@ -1,16 +1,17 @@
 import { Route, Routes } from 'react-router-dom';
+
+import { AlarmPage } from '@/pages/alarm';
+import { ComparisonPage } from '@/pages/comparison';
 import { HomePage } from '@/pages/home';
+import { LoginPage } from '@/pages/login';
+import { MyPage } from '@/pages/my';
+import { SignupPage } from '@/pages/signup';
 import {
   SubscriptionDetailPage,
   SubscriptionEditPage,
   SubscriptionsPage,
 } from '@/pages/subscriptions';
-import { ComparisonPage } from '@/pages/comparison';
-import { MyPage } from '@/pages/my';
-import { AlarmPage } from '@/pages/alarm';
-import { LoginPage } from '@/pages/login';
 import { ROUTES } from '@/shared/config/routes';
-import { SignupPage } from '@/pages/signup';
 
 
 export const AppRouter = () => (

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -1,15 +1,22 @@
 import AlarmButton from '@/shared/ui/button/AlarmButton';
 import { MobileLayout } from '@/shared/ui/layout';
+import { ServiceIdentity } from '@/shared/ui/service-identity';
 
 export const HomePage = () => (
   <MobileLayout
     headerProps={{
       leftSlot: 'Logo',
       rightSlot: <AlarmButton />,
-      colorVariant: 'gray',
+      colorVariant: 'white',
     }}
     bodyVariant="gray"
   >
-    HomePage
+    <ServiceIdentity
+      serviceName="쿠팡 와우"
+      category="쇼핑"
+      imageUrl="https://blog.kakaocdn.net/dna/kEtR9/btrgfMGHvbz/AAAAAAAAAAAAAAAAAAAAAFnlHYpDkUsQtU0PpJmF9um5YJwR0ZuhoUk71wNnibV3/img.png?credential=yqXZFxpELC7KVnFOS48ylbz2pIh7yKj8&expires=1756652399&allow_ip=&allow_referer=&signature=KwdcSm%2B2yKL%2BAnqJlLsE9GU56Ts%3D"
+      size="xl"
+      tagClassName="py-1"
+    />
   </MobileLayout>
 );

--- a/src/pages/login/LoginPage.tsx
+++ b/src/pages/login/LoginPage.tsx
@@ -1,7 +1,8 @@
+import { useNavigate } from 'react-router-dom';
+
 import { ROUTES } from '@/shared/config/routes';
 import LoginButton from '@/shared/ui/button/LoginButton';
 import { Header } from '@/shared/ui/header';
-import { useNavigate } from 'react-router-dom';
 
 export const LoginPage = () => {
   const navigate = useNavigate();

--- a/src/pages/subscriptions/SubscriptionDetailPage.tsx
+++ b/src/pages/subscriptions/SubscriptionDetailPage.tsx
@@ -1,9 +1,10 @@
+import { useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+
 import { ROUTES } from '@/shared/config/routes';
 import BackButton from '@/shared/ui/button/BackButton';
 import StarButton from '@/shared/ui/button/StarButton';
 import { MobileLayout } from '@/shared/ui/layout';
-import { useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
 
 const SubscriptionRightSlot = () => {
   const [isStarred, setIsStarred] = useState(false);

--- a/src/shared/assets/icons/index.ts
+++ b/src/shared/assets/icons/index.ts
@@ -8,13 +8,13 @@ import RightIcon from './chevron-right.svg?react';
 import CloseIcon from './close.svg?react';
 import ComparisonIcon from './comparison.svg?react';
 import HomeIcon from './home.svg?react';
+import KaKaoIcon from './kakao.svg?react';
 import PlusIcon from './plus.svg?react';
 import QuestionIcon from './question-circle.svg?react';
+import StarFilledIcon from './star-solid.svg?react';
 import StarIcon from './star.svg?react';
 import SubIcon from './sub.svg?react';
 import UserIcon from './user-profile.svg?react';
-import KaKaoIcon from './kakao.svg?react';
-import StarFilledIcon from './star-solid.svg?react';
 
 export const Icons = {
   Alarm: AlarmIcon,

--- a/src/shared/ui/bottom-navigation/BottomNavigation.tsx
+++ b/src/shared/ui/bottom-navigation/BottomNavigation.tsx
@@ -1,7 +1,9 @@
+import { NavLink } from 'react-router-dom';
+
 import { Icons } from '@/shared/assets/icons';
 import { ROUTES } from '@/shared/config/routes';
-import { Icon, IconProps } from '@/shared/ui/icon';
-import { NavLink } from 'react-router-dom';
+import type { IconProps } from '@/shared/ui/icon';
+import { Icon } from '@/shared/ui/icon';
 
 interface NavItem {
   id: string;

--- a/src/shared/ui/button/AlarmButton.tsx
+++ b/src/shared/ui/button/AlarmButton.tsx
@@ -1,7 +1,8 @@
 import { useNavigate } from 'react-router-dom';
+
 import { Icons } from '@/shared/assets/icons';
-import IconButton from '@/shared/ui/button/IconButton';
 import { ROUTES } from '@/shared/config/routes';
+import IconButton from '@/shared/ui/button/IconButton';
 
 interface AlarmButtonProps {
   tone?: 'default' | 'white';

--- a/src/shared/ui/button/BackButton.tsx
+++ b/src/shared/ui/button/BackButton.tsx
@@ -1,4 +1,5 @@
 import { useNavigate } from 'react-router-dom';
+
 import { Icons } from '@/shared/assets/icons';
 import IconButton from '@/shared/ui/button/IconButton';
 

--- a/src/shared/ui/filter/Filter.tsx
+++ b/src/shared/ui/filter/Filter.tsx
@@ -19,7 +19,7 @@ interface FilterProps {
   label: string; // 드롭다운 버튼에 표시될 텍스트
   items: FilterOption[]; // 드롭다운 항목 리스트
   initialValue?: string; // 선택된 항목의 초기값
-  // eslint-disable-next-line
+   
   onSelect: (value: string) => void; // 항목 선택 시 호출될 콜백 함수
 }
 

--- a/src/shared/ui/service-identity/ServiceIdentity.tsx
+++ b/src/shared/ui/service-identity/ServiceIdentity.tsx
@@ -1,6 +1,7 @@
+import { useId, useState } from 'react';
+
 import { cn } from '@/lib/utils'; // clsx + tailwind-merge 유틸
 import { Tag } from '@/shared/ui/tag';
-import { useId, useState } from 'react';
 
 /**
  * 아이콘 + 서비스명 + 태그 묶음

--- a/src/shared/ui/service-identity/ServiceIdentity.tsx
+++ b/src/shared/ui/service-identity/ServiceIdentity.tsx
@@ -27,8 +27,8 @@ export interface ServiceIdentityProps {
 }
 
 const ICON_SIZE = {
-  md: 'size-16 rounded-xl',
-  lg: 'size-24 rounded-2xl',
+  md: 'size-12 rounded-xl',
+  lg: 'size-16 rounded-2xl',
   xl: 'size-[82px] rounded-2xl',
 } as const;
 
@@ -69,8 +69,8 @@ export const ServiceIdentity = ({
           src={imageUrl}
           alt={`${serviceName} 아이콘`}
           loading="lazy"
-          width={82}
-          height={82}
+          width={{ md: 48, lg: 64, xl: 82 }[size]}
+          height={{ md: 64, lg: 64, xl: 82 }[size]}
           className={cn('object-cover', ICON_SIZE[size])}
           onError={() => setImgError(true)}
         />

--- a/src/shared/ui/service-identity/ServiceIdentity.tsx
+++ b/src/shared/ui/service-identity/ServiceIdentity.tsx
@@ -1,4 +1,4 @@
-import { useId, useState } from 'react';
+import { useEffect, useId, useState } from 'react';
 
 import { cn } from '@/lib/utils'; // clsx + tailwind-merge 유틸
 import { Tag } from '@/shared/ui/tag';
@@ -42,6 +42,11 @@ export const ServiceIdentity = ({
 }: ServiceIdentityProps) => {
   const titleId = useId();
   const [imgError, setImgError] = useState(false);
+
+  useEffect(() => {
+    // 이미지 URL이 바뀌면 에러 상태 초기화
+    setImgError(false);
+  }, [imageUrl]);
 
   return (
     // figure/figcaption 시맨틱으로 제목과 시각자료를 묶음

--- a/src/shared/ui/service-identity/ServiceIdentity.tsx
+++ b/src/shared/ui/service-identity/ServiceIdentity.tsx
@@ -1,0 +1,86 @@
+import { cn } from '@/lib/utils'; // clsx + tailwind-merge 유틸
+import { Tag } from '@/shared/ui/tag';
+import { useId, useState } from 'react';
+
+/**
+ * 아이콘 + 서비스명 + 태그 묶음
+ * - 단순 프레젠테이션 컴포넌트 (공통 Tag 재사용)
+ * - 그림이 핵심 정보이므로 img에 의미 있는 alt 제공
+ * - 이미지 실패 시 이니셜 fallback 제공
+ */
+
+export interface ServiceIdentityProps {
+  /** 서비스명 (텍스트 및 img 대체 텍스트로 사용) */
+  serviceName: string;
+  /** 카테고리 라벨 (예: '쇼핑', 'OTT') */
+  category: string;
+  /** 정사각 아이콘 URL */
+  imageUrl: string;
+
+  /** 아이콘 크기 프리셋 */
+  size?: 'md' | 'lg' | 'xl';
+  /** 전체 래퍼 클래스 */
+  className?: string;
+  /** Tag 커스터마이즈가 필요할 때 */
+  tagClassName?: string;
+}
+
+const ICON_SIZE = {
+  md: 'size-16 rounded-xl',
+  lg: 'size-24 rounded-2xl',
+  xl: 'size-[82px] rounded-2xl',
+} as const;
+
+export const ServiceIdentity = ({
+  serviceName,
+  category,
+  imageUrl,
+  size = 'xl',
+  className,
+  tagClassName,
+}: ServiceIdentityProps) => {
+  const titleId = useId();
+  const [imgError, setImgError] = useState(false);
+
+  return (
+    // figure/figcaption 시맨틱으로 제목과 시각자료를 묶음
+    <figure aria-labelledby={titleId} className={cn('flex flex-col items-center gap-3', className)}>
+      {/* 아이콘 */}
+      {imgError ? (
+        // 이미지 실패 시 이니셜 fallback (접근성: 장식 처리)
+        <div
+          aria-hidden
+          className={cn(
+            'grid place-items-center bg-gray-100 text-gray-400 typo-title-l-bold',
+            'select-none',
+            ICON_SIZE[size],
+          )}
+        >
+          {serviceName?.[0] ?? '?'}
+        </div>
+      ) : (
+        <img
+          src={imageUrl}
+          alt={`${serviceName} 아이콘`}
+          loading="lazy"
+          width={82}
+          height={82}
+          className={cn('object-cover', ICON_SIZE[size])}
+          onError={() => setImgError(true)}
+        />
+      )}
+
+      {/* 제목 + 태그 라인 */}
+      <figcaption className="flex items-center gap-2">
+        <h3 id={titleId} className="typo-title-l-bold text-gray-900">
+          {serviceName}
+        </h3>
+
+        {/* 기존 Tag 컴포넌트 활용 (outline 스타일 가정) */}
+        <Tag appearance="outline" color="red" className={tagClassName}>
+          {category}
+        </Tag>
+      </figcaption>
+    </figure>
+  );
+};

--- a/src/shared/ui/service-identity/index.ts
+++ b/src/shared/ui/service-identity/index.ts
@@ -1,0 +1,2 @@
+export { ServiceIdentity } from './ServiceIdentity';
+export type { ServiceIdentityProps } from './ServiceIdentity';

--- a/src/widgets/payment-summary/ui/PaymentSummaryBlock.tsx
+++ b/src/widgets/payment-summary/ui/PaymentSummaryBlock.tsx
@@ -7,10 +7,6 @@ import { Tag } from '@/shared/ui/tag';
 
 import { PaymentSummaryCard } from './PaymentSummaryCard';
 
-// 임시 아이콘/서비스명(실제 API 나오면 대체)
-const FALLBACK_ICON = '/assets/netflix.png';
-const FALLBACK_SERVICE = 'Netflix';
-
 // 임시 인터페이스
 interface PaymentSummaryData {
   userName: string;


### PR DESCRIPTION
## #️⃣ 연관된 이슈 (선택)



## 📝 작업 내용

임시로 아이콘 경로 하드코딩해서 구현했습니다.
상세 정보 페이지에서 사용될 예정입니다.

<img width="149" height="129" alt="image" src="https://github.com/user-attachments/assets/98116669-67f2-4852-8c16-f2ccdcdec2b0" />


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - ServiceIdentity 컴포넌트 도입으로 서비스 아이콘·이름·카테고리를 일관된 블록으로 표시.
  - 홈 화면에 ServiceIdentity 적용으로 첫 화면 시각 정보 강화.
- 스타일
  - 홈 헤더 우측 색상을 흰색으로 조정해 대비 개선.
- 리팩터
  - 여러 파일에서 임포트 정리·중복 제거로 가독성 및 유지보수성 향상.
- 기타(Chores)
  - 불필요한 린트 예외 및 사용되지 않는 임시 상수 삭제.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->