### PR TITLE
fix: 비교 페이지 내구독 섹션에서 커스텀 구독 제외한다

### DIFF
--- a/src/entities/subscription/api/fetchMySubscription.ts
+++ b/src/entities/subscription/api/fetchMySubscription.ts
@@ -14,6 +14,7 @@ export type SubscriptionService = {
   isFavorites: boolean;
   imageUrl: string;
   startedAt?: string; // 날짜 형식이므로 string
+  isCustom?: boolean;
 };
 
 // API 응답의 data 객체에 대한 타입

--- a/src/pages/comparison/ComparisonPage.tsx
+++ b/src/pages/comparison/ComparisonPage.tsx
@@ -40,6 +40,8 @@ export const ComparisonPage = () => {
   const { data: products } = useProducts(category);
   const { data: mySubs = { services: [] } } = useMySubscription({ category, sort: 'NAME' });
 
+  const filteredNotCustom = mySubs.services.filter(sub => !sub.isCustom);
+
   /** --- 쿼리 파라미터 없는 경우 초기 카테고리 적용 --- * */
   useEffect(() => {
     if (!queryParams.get('category')) {
@@ -154,7 +156,7 @@ export const ComparisonPage = () => {
           {mySubs?.services?.length > 0 && (
             <ComparisonMySubSection
               category={currentCategoryLabel}
-              mySubs={mySubs.services}
+              mySubs={filteredNotCustom}
               selectedSubs={selectedSubs}
               handleSelect={handleSelectSub}
               handleDetail={handleShowDetail}


### PR DESCRIPTION
## #️⃣ 연관된 이슈 (선택)

> ex) #이슈번호, #이슈번호

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 비교 페이지의 "내 구독" 섹션에서 커스텀 구독이 자동으로 제외되어 기본 제공 구독만 표시됩니다. 목록이 더 간결하게 보입니다.
  * 구독 서비스 항목에 커스텀 여부를 나타내는 선택적 속성이 추가되어, 앱이 커스텀 구독을 인식해 표시 및 필터링에 반영합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->